### PR TITLE
Update to TLS 1.2

### DIFF
--- a/src/PaypalIPNListener.php
+++ b/src/PaypalIPNListener.php
@@ -109,7 +109,7 @@ class PaypalIPNListener {
         curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, true);
-        curl_setopt($ch, CURLOPT_SSLVERSION, 4);
+        curl_setopt($ch, CURLOPT_SSLVERSION, 6);
         
         $this->response = curl_exec($ch);
         $this->response_status = strval(curl_getinfo($ch, CURLINFO_HTTP_CODE));


### PR DESCRIPTION
As of 2016, Paypal requires TLS 1.2
https://devblog.paypal.com/upcoming-security-changes-notice/